### PR TITLE
Update BC to 1.61

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,8 @@
 
   :dependencies
   [[org.clojure/clojure "1.8.0" :scope "provided"]
-   [org.bouncycastle/bcpg-jdk15on "1.58"]
-   [org.bouncycastle/bcprov-jdk15on "1.58"]
+   [org.bouncycastle/bcpg-jdk15on "1.61"]
+   [org.bouncycastle/bcprov-jdk15on "1.61"]
    [byte-streams "0.2.3"]]
 
   :hiera


### PR DESCRIPTION
This is necessary to use .kbx files used GPG by 2.1

All tests passing