### PR TITLE
Extended the MessagePacket protocol to support PGPMarker

### DIFF
--- a/src/clj_pgp/message.clj
+++ b/src/clj_pgp/message.clj
@@ -169,7 +169,7 @@
     ;; beginning of a message that uses features not available in PGP 2.6.x
     ;; in order to cause that version to report that newer software is
     ;; necessary to process the message.
-    [])
+    acc)
 
   (readable
     [packet opts]

--- a/src/clj_pgp/message.clj
+++ b/src/clj_pgp/message.clj
@@ -40,6 +40,7 @@
       PGPEncryptedDataList
       PGPLiteralData
       PGPLiteralDataGenerator
+      PGPMarker
       PGPObjectFactory
       PGPPublicKeyEncryptedData
       PGPUtil)
@@ -157,6 +158,22 @@
   (readable
     [packet opts]
     ;; PGPLiteralData is always readable
+    packet)
+
+
+  PGPMarker
+
+  (reduce-message
+    [packet opts rf acc]
+    ;; Such a packet MUST be ignored when received. It may be placed at the
+    ;; beginning of a message that uses features not available in PGP 2.6.x
+    ;; in order to cause that version to report that newer software is
+    ;; necessary to process the message.
+    [])
+
+  (readable
+    [packet opts]
+    ;; PGPMarker is always readable
     packet))
 
 


### PR DESCRIPTION
Should be pretty self-explanatory. Description of functionality and desired behavior shamelessly copped from the OpenPGP spec via https://stackoverflow.com/questions/17790215/why-do-i-find-pgpmarker-when-expecting-pgpliteraldata-in-bouncycastle#17793801