### PR TITLE
Adds support for custom error handling.

### DIFF
--- a/src/clj_pgp/core.clj
+++ b/src/clj_pgp/core.clj
@@ -4,7 +4,8 @@
     [byte-streams :as bytes]
     [clojure.java.io :as io]
     [clojure.string :as str]
-    [clj-pgp.tags :as tags])
+    [clj-pgp.tags :as tags]
+    [clj-pgp.error :as error])
   (:import
     (java.io
       ByteArrayOutputStream
@@ -258,9 +259,16 @@
   "Lazily decodes a sequence of PGP objects from an input stream."
   [^InputStream input]
   (let [factory (PGPObjectFactory. input (BcKeyFingerprintCalculator.))]
-    (->>
-      (repeatedly #(.nextObject factory))
-      (take-while some?))))
+    (->> (range)
+         (map (fn [n]
+                (try
+                  (.nextObject factory)
+                  (catch Exception e
+                    (error/*handler* ::read-object-error
+                                     (.getMessage e)
+                                     (assoc (ex-data e) :stream input :nth n)
+                                     e)))))
+         (take-while some?))))
 
 
 (defn decode

--- a/src/clj_pgp/core.clj
+++ b/src/clj_pgp/core.clj
@@ -255,7 +255,9 @@
 
 ;; ## PGP Object Decoding
 
-(defn ^:no-doc read-next-object [factory]
+(defn read-next-object
+  "A thin wrapper on reading the next object from a PGPObjectFactory."
+  [^PGPObjectFactory factory]
   (.nextObject factory))
 
 (defn ^:no-doc read-objects

--- a/src/clj_pgp/core.clj
+++ b/src/clj_pgp/core.clj
@@ -255,18 +255,21 @@
 
 ;; ## PGP Object Decoding
 
+(defn ^:no-doc read-next-object [factory]
+  (.nextObject factory))
+
 (defn ^:no-doc read-objects
   "Lazily decodes a sequence of PGP objects from an input stream."
   [^InputStream input]
   (let [factory (PGPObjectFactory. input (BcKeyFingerprintCalculator.))]
     (->> (range)
-         (map (fn [n]
+         (map (fn next-object [n]
                 (try
-                  (.nextObject factory)
+                  (read-next-object factory)
                   (catch Exception e
                     (error/*handler* ::read-object-error
                                      (.getMessage e)
-                                     (assoc (ex-data e) :stream input :nth n)
+                                     (assoc (ex-data e) ::stream input ::nth n)
                                      e)))))
          (take-while some?))))
 

--- a/src/clj_pgp/error.clj
+++ b/src/clj_pgp/error.clj
@@ -1,0 +1,11 @@
+(ns clj-pgp.error)
+
+(defn default-error-handler
+  [error-type message data cause]
+  (throw (ex-info message (assoc data :pgp/error error-type) cause)))
+
+(def ^:dynamic *handler*
+  "Dynamic error handler"
+  default-error-handler)
+
+(derive :clj-pgp.core/read-object-error ::decrypt-error)

--- a/test/clj_pgp/test/encryption.clj
+++ b/test/clj_pgp/test/encryption.clj
@@ -93,15 +93,12 @@
             "Message should wrap a literal packet around the data.")
         (is (bytes= data (:data (first (pgp-msg/read-messages envelope))))
             "Literal packet message should be readable with no decryptors.")))
-
-    
     (let [ciphertext (pgp-msg/encrypt data keypair)]
       (is (bytes= data (pgp-msg/decrypt ciphertext (constantly keypair)))
           "Decrypting with a keypair-retrieval function returns the data.")
       (is (thrown? IllegalArgumentException
             (pgp-msg/decrypt ciphertext "passphrase"))
           "Decrypting without a matching key throws an exception")
-
       (testing "should allow overriding error behavior with custom behavior"
         (let [error-occured? (atom false)
               error-handler (fn [type message data cause]

--- a/test/clj_pgp/test/encryption.clj
+++ b/test/clj_pgp/test/encryption.clj
@@ -15,7 +15,8 @@
      [gen-ec-keyspec
       gen-rsa-keyspec
       spec->keypair
-      memospec->keypair]])
+      memospec->keypair]]
+    [clj-pgp.error :as error])
   (:import
     java.io.ByteArrayOutputStream
     java.security.SecureRandom))
@@ -92,12 +93,24 @@
             "Message should wrap a literal packet around the data.")
         (is (bytes= data (:data (first (pgp-msg/read-messages envelope))))
             "Literal packet message should be readable with no decryptors.")))
+
+    
     (let [ciphertext (pgp-msg/encrypt data keypair)]
       (is (bytes= data (pgp-msg/decrypt ciphertext (constantly keypair)))
           "Decrypting with a keypair-retrieval function returns the data.")
       (is (thrown? IllegalArgumentException
             (pgp-msg/decrypt ciphertext "passphrase"))
-          "Decrypting without a matching key throws an exception"))))
+          "Decrypting without a matching key throws an exception")
+
+      (testing "should allow overriding error behavior with custom behavior"
+        (let [error-occured? (atom false)
+              error-handler (fn [type message data cause]
+                              (reset! error-occured? true)
+                              nil)]
+          (with-redefs [pgp/read-next-object (fn [_] (throw (Exception. "Simulating PGP nextObject error")))]
+            (binding [error/*handler* error-handler]
+              (pgp-msg/decrypt ciphertext (constantly keypair))
+              (is @error-occured? "A PGP error was simulated but not passed to the error handler."))))))))
 
 
 (deftest encryption-scenarios


### PR DESCRIPTION
This adopts the pattern of clj-cbor for clj-pgp. It doesn't apply the pattern everywhere, but allows users to have partial success when there is a single error in a pgp stream.

Couple notes: 
Unlike clj-cbor, I decided to support a `cause`, to allow deeper exception context to be supported if the consumer wants to surface that. 