### PR TITLE
Make `read-objects` implement `IReduceInit` instead of a lazy-seq

### DIFF
--- a/src/clj_pgp/core.clj
+++ b/src/clj_pgp/core.clj
@@ -262,21 +262,36 @@
   (.nextObject factory))
 
 
+(defn ^:no-doc try-read-object
+  "Tries to read and return a single object from a given
+  PGPObjectFactory calling the error/*handler* upon an exception."
+  [factory input n]
+  (try
+    (read-next-object factory)
+    (catch Exception e
+      (error/*handler* ::read-object-error
+                       (.getMessage e)
+                       (assoc (ex-data e) ::stream input ::nth n)
+                       e))))
+
+
 (defn ^:no-doc read-objects
-  "Lazily decodes a sequence of PGP objects from an input stream."
+  "Decodes a sequence of PGP objects from an input stream."
   [^InputStream input]
-  (let [factory (PGPObjectFactory. input (BcKeyFingerprintCalculator.))]
-    (->> (range)
-         (map (fn next-object
-                [n]
-                (try
-                  (read-next-object factory)
-                  (catch Exception e
-                    (error/*handler* ::read-object-error
-                                     (.getMessage e)
-                                     (assoc (ex-data e) ::stream input ::nth n)
-                                     e)))))
-         (take-while some?))))
+  (reify
+    clojure.lang.IReduceInit
+    (reduce
+      [_ rf init]
+      (let [factory (PGPObjectFactory. input (BcKeyFingerprintCalculator.))]
+        (loop [acc init
+               n 0
+               obj (try-read-object factory input n)]
+          (if (or (reduced? acc)
+                  (not obj))
+            (unreduced acc)
+            (recur (rf acc obj)
+                   (inc n)
+                   (try-read-object factory input (inc n)))))))))
 
 
 (defn decode
@@ -285,7 +300,7 @@
   [data]
   (with-open [stream (PGPUtil/getDecoderStream
                        (bytes/to-input-stream data))]
-    (doall (read-objects stream))))
+    (into '() (read-objects stream))))
 
 
 (defn decode-public-key

--- a/src/clj_pgp/core.clj
+++ b/src/clj_pgp/core.clj
@@ -278,20 +278,18 @@
 (defn ^:no-doc read-objects
   "Decodes a sequence of PGP objects from an input stream."
   [^InputStream input]
-  (reify
-    clojure.lang.IReduceInit
+  (reify clojure.lang.IReduceInit
     (reduce
       [_ rf init]
       (let [factory (PGPObjectFactory. input (BcKeyFingerprintCalculator.))]
         (loop [acc init
-               n 0
-               obj (try-read-object factory input n)]
-          (if (or (reduced? acc)
-                  (not obj))
-            (unreduced acc)
-            (recur (rf acc obj)
-                   (inc n)
-                   (try-read-object factory input (inc n)))))))))
+               n 0]
+          (let [obj (try-read-object factory input n)]
+            (if (or (reduced? acc)
+                    (not obj))
+              (unreduced acc)
+              (recur (rf acc obj)
+                     (inc n)))))))))
 
 
 (defn decode
@@ -300,7 +298,7 @@
   [data]
   (with-open [stream (PGPUtil/getDecoderStream
                        (bytes/to-input-stream data))]
-    (into '() (read-objects stream))))
+    (into [] (read-objects stream))))
 
 
 (defn decode-public-key


### PR DESCRIPTION
We encountered an issue with a PGP encrypted file where it appeared that an exception was thrown when trying to read the second object in the PGP input stream. Even though we only cared about the first object, the `read-next-object` *could* be called on the second object due to chunking in the lazy sequence returned by `read-objects`.

This changes the implementation of `read-objects` to implement `IReduceInit` instead, so that a caller can shortcut the reduction by using `reduced`.