### PR TITLE
Update dependencies (primarily Bouncy Castle libs)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,8 +15,7 @@
   [[org.clojure/clojure "1.10.3" :scope "provided"]
    [org.bouncycastle/bcpg-jdk15on "1.70"]
    [org.bouncycastle/bcprov-jdk15on "1.70"]
-   [org.clj-commons/byte-streams "0.2.10"]
-   [org.clojure/tools.logging "1.2.4"]]
+   [org.clj-commons/byte-streams "0.2.10"]]
 
   :hiera
   {:cluster-depth 1}
@@ -30,7 +29,8 @@
     :dependencies [[org.clojure/tools.namespace "1.2.0"]]}
 
    :coverage
-   {:plugins [[lein-cloverage "1.2.2"]]}
+   {:plugins [[lein-cloverage "1.2.2"]]
+    :dependencies [[org.clojure/tools.logging "1.2.4"]]}
 
    :tool
    {:source-paths ["tool"]

--- a/project.clj
+++ b/project.clj
@@ -12,26 +12,27 @@
   :pedantic? :abort
 
   :dependencies
-  [[org.clojure/clojure "1.10.1" :scope "provided"]
-   [org.bouncycastle/bcpg-jdk15on "1.66"]
-   [org.bouncycastle/bcprov-jdk15on "1.66"]
-   [byte-streams "0.2.4"]]
+  [[org.clojure/clojure "1.10.3" :scope "provided"]
+   [org.bouncycastle/bcpg-jdk15on "1.70"]
+   [org.bouncycastle/bcprov-jdk15on "1.70"]
+   [org.clj-commons/byte-streams "0.2.10"]
+   [org.clojure/tools.logging "1.2.4"]]
 
   :hiera
   {:cluster-depth 1}
 
   :profiles
   {:dev
-   {:dependencies [[org.clojure/test.check "1.1.0"]]}
+   {:dependencies [[org.clojure/test.check "1.1.1"]]}
 
    :repl
    {:source-paths ["dev"]
-    :dependencies [[org.clojure/tools.namespace "1.0.0"]]}
+    :dependencies [[org.clojure/tools.namespace "1.2.0"]]}
 
    :coverage
-   {:plugins [[lein-cloverage "1.1.0"]]}
+   {:plugins [[lein-cloverage "1.2.2"]]}
 
    :tool
    {:source-paths ["tool"]
-    :dependencies [[mvxcvi/puget "1.3.1"]]
+    :dependencies [[mvxcvi/puget "1.3.2"]]
     :jvm-opts []}})


### PR DESCRIPTION
To fix CVE-2020-28052 upgrade the Bouncy Castle libraries to the recent version v1.70.

With this update also the other dependencies can be bumped to the recent versions.