### PR TITLE
upgraded bouncycastle and byte-streams

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,6 +1,6 @@
 (ns user
   (:require
-    [byte-streams :as bytes]
+    [clj-commons.byte-streams :as bytes]
     [clj-pgp.core :as pgp]
     [clj-pgp.tags :as tags]
     [clj-pgp.test.keys :as test-keys]

--- a/project.clj
+++ b/project.clj
@@ -13,9 +13,9 @@
 
   :dependencies
   [[org.clojure/clojure "1.10.3" :scope "provided"]
-   [org.bouncycastle/bcpg-jdk15on "1.70"]
-   [org.bouncycastle/bcprov-jdk15on "1.70"]
-   [org.clj-commons/byte-streams "0.2.10"]]
+   [org.bouncycastle/bcpg-jdk18on "1.77"]
+   [org.bouncycastle/bcprov-jdk18on "1.77"]
+   [org.clj-commons/byte-streams "0.3.4"]]
 
   :hiera
   {:cluster-depth 1}

--- a/src/clj_pgp/core.clj
+++ b/src/clj_pgp/core.clj
@@ -1,7 +1,7 @@
 (ns clj-pgp.core
   "Core functions for handling PGP objects."
   (:require
-    [byte-streams :as bytes]
+    [clj-commons.byte-streams :as bytes]
     [clj-pgp.error :as error]
     [clj-pgp.tags :as tags]
     [clojure.java.io :as io]

--- a/src/clj_pgp/keyring.clj
+++ b/src/clj_pgp/keyring.clj
@@ -4,7 +4,7 @@
   Literal keyring files are directly supported, and key servers and other
   stores can extend the `KeyRing` protocol for further extension."
   (:require
-    [byte-streams :as bytes]
+    [clj-commons.byte-streams :as bytes]
     [clj-pgp.core :as pgp])
   (:import
     (org.bouncycastle.openpgp

--- a/src/clj_pgp/message.clj
+++ b/src/clj_pgp/message.clj
@@ -14,7 +14,7 @@
   a function which accepts a key id and returns the corresponding private-key,
   to look it up or unlock the key on demand."
   (:require
-    [byte-streams :as bytes]
+    [clj-commons.byte-streams :as bytes]
     [clj-pgp.core :as pgp]
     [clj-pgp.tags :as tags]
     [clj-pgp.util :refer [arg-coll arg-map]]

--- a/src/clj_pgp/signature.clj
+++ b/src/clj_pgp/signature.clj
@@ -1,7 +1,7 @@
 (ns clj-pgp.signature
   "The functions in this namespace generate and verify PGP signatures."
   (:require
-    [byte-streams :as bytes]
+    [clj-commons.byte-streams :as bytes]
     [clj-pgp.core :as pgp]
     [clj-pgp.tags :as tags]
     [clj-pgp.util :refer [arg-map]])

--- a/test/clj_pgp/test/encryption.clj
+++ b/test/clj_pgp/test/encryption.clj
@@ -1,6 +1,6 @@
 (ns clj-pgp.test.encryption
   (:require
-    [byte-streams :refer [bytes=] :as bytes]
+    [clj-commons.byte-streams :refer [bytes=] :as bytes]
     [clj-pgp.core :as pgp]
     [clj-pgp.error :as error]
     [clj-pgp.generate :as pgp-gen]

--- a/test/clj_pgp/test/key_utils.clj
+++ b/test/clj_pgp/test/key_utils.clj
@@ -1,6 +1,6 @@
 (ns clj-pgp.test.key-utils
   (:require
-    [byte-streams :refer [bytes=]]
+    [clj-commons.byte-streams :refer [bytes=]]
     [clj-pgp.core :as pgp]
     [clj-pgp.keyring :as keyring]
     [clj-pgp.test.keys :as test-keys

--- a/test/clj_pgp/test/signing.clj
+++ b/test/clj_pgp/test/signing.clj
@@ -1,6 +1,6 @@
 (ns clj-pgp.test.signing
   (:require
-    [byte-streams :refer [bytes=]]
+    [clj-commons.byte-streams :refer [bytes=]]
     [clj-pgp.core :as pgp]
     [clj-pgp.generate :as pgp-gen]
     [clj-pgp.signature :as pgp-sig]


### PR DESCRIPTION
- upgrade bouncycastle to address CVE-2023-33201
- upgrade byte-streams and fix deprecations from https://github.com/clj-commons/byte-streams/blob/master/CHANGELOG.adoc