### PR TITLE
Handle empty PGPEncryptedDataList packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-#### Changed
+### Changed
 - Add handling for empty `PGPEncryptedDataList` packets.
   [PR#30](https://github.com/greglook/clj-pgp/pull/30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ...
 
 
+## [1.1.2] - 2024-11-16
+
+### Changed
+- Add handling for empty `PGPEncryptedDataList` packets.
+  [PR#30](https://github.com/greglook/clj-pgp/pull/30)
+
 ## [1.1.1] - 2023-11-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
-
-
-## [1.1.2] - 2024-11-16
-
-### Changed
+#### Changed
 - Add handling for empty `PGPEncryptedDataList` packets.
   [PR#30](https://github.com/greglook/clj-pgp/pull/30)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mvxcvi/clj-pgp "1.1.1"
+(defproject mvxcvi/clj-pgp "1.1.2"
   :description "Wrapper for the Bouncy Castle OpenPGP library"
   :url "https://github.com/greglook/clj-pgp"
   :license {:name "Public Domain"

--- a/src/clj_pgp/message.clj
+++ b/src/clj_pgp/message.clj
@@ -285,9 +285,11 @@
     [packet opts rf acc]
     (if-let [readable-packet (readable packet opts)]
       (reduce-message readable-packet opts rf acc)
-      (throw (IllegalArgumentException.
-               (str "Cannot decrypt " (pr-str packet) " with " (pr-str opts)
-                    " (no matching encrypted session key)")))))
+      (if (.isEmpty packet)
+        acc
+        (throw (IllegalArgumentException.
+                 (str "Cannot decrypt " (pr-str packet) " with " (pr-str opts)
+                      " (no matching encrypted session key)"))))))
 
   (readable
     [packet opts]

--- a/test/clj_pgp/test/encryption.clj
+++ b/test/clj_pgp/test/encryption.clj
@@ -14,7 +14,8 @@
     [clojure.test.check.generators :as gen]
     [clojure.test.check.properties :as prop])
   (:import
-    java.security.SecureRandom))
+    java.security.SecureRandom
+    org.bouncycastle.openpgp.PGPEncryptedDataList))
 
 
 (defn test-encryption-scenario
@@ -103,6 +104,46 @@
             (binding [error/*handler* error-handler]
               (pgp-msg/decrypt ciphertext (constantly keypair))
               (is @error-occured? "A PGP error was simulated but not passed to the error handler."))))))))
+
+
+
+(def ^:private packet-header-byte
+  "
+  From right to left:
+    - Bits 1–0 are set to `00` to indicate a one-octet length packet.
+    - Bits 5–2 specify the packet's tag, which is `0001`.
+    - Bit 6 is `0` to indicate an 'old format' packet.
+    - Bit 7 is always `1` in a packet header.
+  See RFC 4880 section 4.2.
+  "
+  2r10000100)
+
+
+(def ^:private packet-length-byte
+  "
+  A packet's length doesn't include the first two header bytes.
+  This is an empty packet, so we're just using `0`
+  "
+  2r00000000)
+
+
+(def ^:private packet-count-byte
+  "
+  I honestly don't understand why we need this byte or what it represents
+  but bouncycastle's constructor will throw without it.
+  Arrived at it via LLM + trial + error
+  "
+  2r10000000)
+
+
+(deftest empty-packet-handling
+  (let [empty-packet (PGPEncryptedDataList.
+                       (byte-array [packet-header-byte
+                                    packet-length-byte
+                                    packet-count-byte]))
+        accumulator [:accumulated :data]]
+    (is (= accumulator (pgp-msg/reduce-message empty-packet {} #() accumulator))
+        "When given an empty packet, we should return the accumulator instead of throwing")))
 
 
 (deftest encryption-scenarios

--- a/test/clj_pgp/test/encryption.clj
+++ b/test/clj_pgp/test/encryption.clj
@@ -106,7 +106,6 @@
               (is @error-occured? "A PGP error was simulated but not passed to the error handler."))))))))
 
 
-
 (def ^:private packet-header-byte
   "
   From right to left:


### PR DESCRIPTION
## Description

It turns out that `PGPEncryptedDataList` packets [can be empty](https://javadoc.io/static/org.bouncycastle/bcpg-jdk15to18/1.74/org/bouncycastle/openpgp/PGPEncryptedDataList.html#isEmpty()).  Currently, the `reduce-message` handler for such packets will throw an `IllegalArgumentException`.  This PR updates the logic to support simply returning the `acc` in such cases.

## Testing

- Ran this code against a file with an empty packet (the motivation for this PR).
- Added a unit test

---

@greglook, let me know if I didn't properly update the CHANGELOG.
FYI, I opted to call this a "patch" in the SemVer.