### PR TITLE
Removes the deprecated constructor/method usages of bc

### DIFF
--- a/src/clj_pgp/generate.clj
+++ b/src/clj_pgp/generate.clj
@@ -21,6 +21,8 @@
       SECNamedCurves)
     (org.bouncycastle.asn1.x9
       X9ECParameters)
+    (org.bouncycastle.bcpg
+      PublicKeyPacket)
     (org.bouncycastle.bcpg.sig
       Features
       KeyFlags)
@@ -55,6 +57,7 @@
   [^AsymmetricCipherKeyPairGenerator generator
    algorithm]
   (BcPGPKeyPair.
+    PublicKeyPacket/VERSION_4
     (tags/public-key-algorithm-code algorithm)
     (.generateKeyPair generator)
     (Date.)))

--- a/src/clj_pgp/message.clj
+++ b/src/clj_pgp/message.clj
@@ -326,7 +326,7 @@
 
   (reduce-message
     [packet {:keys [decryptor] :as opts} rf acc]
-    (let [for-key (.getKeyID packet)
+    (let [for-key (.getKeyId (.getKeyIdentifier packet))
           privkey (pgp/private-key
                     (if (ifn? decryptor)
                       (decryptor for-key)
@@ -350,7 +350,7 @@
   (readable
     [packet opts]
     (let [decryptor (:decryptor opts)
-          for-key (.getKeyID packet)]
+          for-key (.getKeyId (.getKeyIdentifier packet))]
       (when (some-> (if (ifn? decryptor)
                       (decryptor for-key)
                       decryptor)


### PR DESCRIPTION
Removes the deprecated usages of bc, detected by [eastwood](https://github.com/jonase/eastwood):

- BcPGPKeyPair deprecated constructor [javadoc](https://javadoc.io/doc/org.bouncycastle/bcpg-jdk15to18/latest/org/bouncycastle/openpgp/operator/bc/BcPGPKeyPair.html)
The decision of using PublicKeyPacket/VERSION_4 it's based on the [current default of the deprecated constructor](https://github.com/bcgit/bc-java/blob/main/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyPair.java#L40).

- PGPPublicKeyEncryptedData.getKeyID() [javadoc](https://javadoc.io/static/org.bouncycastle/bcpg-jdk15to18/1.80/org/bouncycastle/openpgp/PGPPublicKeyEncryptedData.html#getKeyID())
